### PR TITLE
Added flags to istanbul to only pull coverage.json from the coverage

### DIFF
--- a/packages/bootleg-common/bin/bootleg-truffle-test
+++ b/packages/bootleg-common/bin/bootleg-truffle-test
@@ -6,5 +6,5 @@ set -e
 . bootleg-setup-ganache
 
 truffle test && bootleg-coverage-ignore && \
-istanbul report text html && \
-istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100
+istanbul report text html --include coverage/coverage.json && \
+istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100 --include coverage/coverage.json

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,7 +1355,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:


### PR DESCRIPTION
**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Update to coverage tool command flags to only pull coverage.json files from the `coverage/` folders

**Description of Changes**  
A defensive change to hopefully prevent against the tooling from reading any/all `coverage.json` files and failing in weird ways. 

**What gif most accurately describes how I feel towards this PR?**  
![Example of a gif](https://media.giphy.com/media/QTdJhJsdHys8w/giphy.gif)
