### PR TITLE
Use BookendToken for the BootlegToken

### DIFF
--- a/packages/bootleg-app-contracts/contracts/BootlegToken.sol
+++ b/packages/bootleg-app-contracts/contracts/BootlegToken.sol
@@ -1,46 +1,21 @@
 pragma solidity ^0.5.0;
 
-import "bootleg-tokens/contracts/AbstractSharedRoyaltyToken.sol";
+import "bootleg-tokens/contracts/BookendSharedRoyaltyToken.sol";
 import "bootleg-tokens/contracts/ERC721/ERC721Enumerable.sol";
 import "bootleg-tokens/contracts/ERC721/ERC721MetadataMintable.sol";
 import "openzeppelin-solidity/contracts/access/roles/MinterRole.sol";
 
-contract BootlegToken is ERC721MetadataMintable, AbstractSharedRoyaltyToken, ERC721Enumerable {
+contract BootlegToken is ERC721MetadataMintable, BookendSharedRoyaltyToken, ERC721Enumerable {
   /**
    * @notice Create a new Bootleg Token Contract
    *
    * @param name - Name of the tokens created
    * @param symbol - Symbol of the tokens created
    */
-  constructor (string memory name, string memory symbol) ERC721Metadata(name, symbol) public {} // solium-disable-line no-empty-blocks
+  constructor (string memory name, string memory symbol, uint256 franchisorPercentage)
+    ERC721Metadata(name, symbol) BookendSharedRoyaltyToken(franchisorPercentage) public
+  {} // solium-disable-line no-empty-blocks
 
-  /**
-   * @notice Gets remaining payment balance accumulated from transfer of a
-   *   given token up to a number of provided payments
-   * @dev Gives the payment to the person who sold it.
-   *
-   * @param franchisor address to get the payment balance of
-   * @param start The payment index to start from
-   * @param count The number of payments to traverse
-   * @param tokenId The identifier for an NFT
-   *
-   * @return uint256 representing the balance in wei accumulated for a token
-   */
-  function paymentBalanceOf(address franchisor, uint256 start, uint256 count, uint256 tokenId) public view returns (uint256) {
-    Token storage token = _tokens[tokenId];
-    uint256 balance = 0;
-    uint256 maxCount = start + count;
-
-    maxCount = maxCount > token.payments.length ? token.payments.length : maxCount;
-
-    for (uint256 i = start; i < maxCount; i += 1) {
-      if (token.franchisors[i - 1] == franchisor) {
-        balance += token.payments[i];
-      }
-    }
-
-    return balance;
-  }
 
   /**
    * @notice Allow the minter to add franchisors. Used for assigning more than one initial position

--- a/packages/bootleg-app-contracts/migrations/2_deploy_and_mint.js
+++ b/packages/bootleg-app-contracts/migrations/2_deploy_and_mint.js
@@ -5,7 +5,7 @@ module.exports = async deployer => {
 
   const accounts = await web3.eth.getAccounts();
 
-  await deployer.deploy(BootlegToken, 'Bootleg', 'BLEG');
+  await deployer.deploy(BootlegToken, 'Bootleg', 'BLEG', 20);
 
   const token = await BootlegToken.deployed();
 

--- a/packages/bootleg-app-contracts/test/BootlegToken.test.js
+++ b/packages/bootleg-app-contracts/test/BootlegToken.test.js
@@ -1,5 +1,5 @@
 const BootlegToken = artifacts.require('BootlegToken');
-const sharedRoyaltyBehavoir = require('bootleg-tokens/test/sharedRoyaltyToken.behavoir');
+const sharedRoyaltyBehavior = require('bootleg-tokens/test/sharedRoyaltyToken.behavior');
 const utilFactory = require('bootleg-tokens/test/erc721UtilFactory');
 
 contract('BootlegToken', accounts => {
@@ -17,7 +17,7 @@ contract('BootlegToken', accounts => {
    */
   const mintToken = async () => {
     const id = web3.utils.asciiToHex('super awesome token id');
-    const instance = await BootlegToken.new('Bootleg', 'BLEG');
+    const instance = await BootlegToken.new('Bootleg', 'BLEG', 5);
 
     await instance.mintWithTokenURI(
       accounts[0],
@@ -28,7 +28,7 @@ contract('BootlegToken', accounts => {
     return { token: instance, tokenId: id };
   };
 
-  sharedRoyaltyBehavoir(mintToken, accounts);
+  sharedRoyaltyBehavior(mintToken, accounts);
 
   beforeEach(async () => {
     const result = await mintToken();

--- a/packages/bootleg-tokens/contracts/BookendSharedRoyaltyToken.sol
+++ b/packages/bootleg-tokens/contracts/BookendSharedRoyaltyToken.sol
@@ -1,29 +1,31 @@
 pragma solidity ^0.5.3;
 
+import "./AbstractSharedRoyaltyToken.sol";
 
-import "./AbstractSharedRoyaltyToken.sol"; 
-import "./ERC721/ERC721Mintable.sol";
 /**
  * @title Shared Royalty Non-Fungible Token Standard basic interface
  */
+contract BookendSharedRoyaltyToken is AbstractSharedRoyaltyToken {
+  uint256 franchisorPercentage;
 
-contract BookendSharedRoyaltyToken is AbstractSharedRoyaltyToken, ERC721Mintable {
-  uint256 franchisorPercentage;   
   constructor(uint256 _franchisorPercentage) public {
     franchisorPercentage = _franchisorPercentage;
   }
+
   /**
    * @notice Calculates the balance owned to the given franchisor, using
-  ***the bookend model, where only the first franchisor and the last
-  ***franchisor get anything. In this implementation, they each get
-  ***50% of the sale.
+   *  the bookend model, where only the first franchisor and the last
+   *  franchisor get anything. In this implementation, they each get
+   *  50% of the sale.
    *
    * @param franchisor request withdrawal
    * @param start the last franchisor that requested withdrawal
    * @param count the number of payments left for this franchisor
    * @param tokenId - id of the token whose payment is being requested
   */
-  function paymentBalanceOf(address franchisor, uint256 start, uint256 count, uint256 tokenId) public view returns (uint256) {    
+  function paymentBalanceOf (address franchisor, uint256 start, uint256 count, uint256 tokenId)
+    public view returns (uint256)
+  {
     Token storage token = _tokens[tokenId];
     uint256 maxCount = start + count;
 
@@ -34,14 +36,14 @@ contract BookendSharedRoyaltyToken is AbstractSharedRoyaltyToken, ERC721Mintable
     // Calculating payments for beginning of bookend
     if (franchisor == _tokens[tokenId].franchisors[0]) {
       for (uint256 i = start; i < maxCount; i++) {
-        payment += (token.payments[i] * (100 - franchisorPercentage))/100;
+        payment += (token.payments[i] * (100 - franchisorPercentage)) / 100;
       }
-    } 
+    }
 
     // Calculating payments for end of bookend
     for (uint256 i = start; i < maxCount; i++) {
       if (token.franchisors[i - 1] == franchisor) {
-        payment += (token.payments[i] * franchisorPercentage)/100;
+        payment += (token.payments[i] * franchisorPercentage) / 100;
         // check for rounding and round up
         if ((token.payments[i] * franchisorPercentage) % 100 != 0) {
           payment += 1;
@@ -50,5 +52,5 @@ contract BookendSharedRoyaltyToken is AbstractSharedRoyaltyToken, ERC721Mintable
     }
 
     return payment;
-  } 
+  }
 }

--- a/packages/bootleg-tokens/contracts/TestSharedRoyaltyToken.sol
+++ b/packages/bootleg-tokens/contracts/TestSharedRoyaltyToken.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "./AbstractSharedRoyaltyToken.sol";
 import "./ERC721/ERC721Mintable.sol";
+import "./BookendSharedRoyaltyToken.sol";
 
 /**
  * @title A Test Shared Royalty Token implemented for testing purposes
@@ -9,32 +9,9 @@ import "./ERC721/ERC721Mintable.sol";
  * @dev You probably don't want to use this in any production form. It's an
  *  example and a basic way to test the Abstract token implementation
  */
-contract TestSharedRoyaltyToken is AbstractSharedRoyaltyToken, ERC721Mintable {
-  /**
-   * @notice Gets remaining payment balance accumulated from transfer of a
-   *   given token up to a number of provided payments
-   * @dev Gives the payment to the person who sold it.
-   *
-   * @param franchisor address to get the payment balance of
-   * @param start The payment index to start from
-   * @param count The number of payments to traverse
-   * @param tokenId The identifier for an NFT
-   *
-   * @return uint256 representing the balance in wei accumulated for a token
-   */
-  function paymentBalanceOf(address franchisor, uint256 start, uint256 count, uint256 tokenId) public view returns (uint256) {
-    Token storage token = _tokens[tokenId];
-    uint256 balance = 0;
-    uint256 maxCount = start + count;
+contract TestSharedRoyaltyToken is BookendSharedRoyaltyToken, ERC721Mintable {
 
-    maxCount = maxCount > token.payments.length ? token.payments.length : maxCount;
-
-    for (uint256 i = start; i < maxCount; i += 1) {
-      if (token.franchisors[i - 1] == franchisor) {
-        balance += token.payments[i];
-      }
-    }
-
-    return balance;
-  }
+  constructor (uint256 franchisorPercentage)
+    BookendSharedRoyaltyToken(franchisorPercentage) public
+  {} // solium-disable-line no-empty-blocks
 }

--- a/packages/bootleg-tokens/migrations/2_deploy_contracts.js
+++ b/packages/bootleg-tokens/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
 const TestSharedRoyaltyToken = artifacts.require('TestSharedRoyaltyToken');
 
 module.exports = function(deployer) {
-  deployer.deploy(TestSharedRoyaltyToken);
+  deployer.deploy(TestSharedRoyaltyToken, 5);
 };

--- a/packages/bootleg-tokens/test/AbstractSharedRoyaltyToken.test.js
+++ b/packages/bootleg-tokens/test/AbstractSharedRoyaltyToken.test.js
@@ -1,5 +1,5 @@
 const TestSharedRoyaltyToken = artifacts.require('TestSharedRoyaltyToken');
-const sharedRoyaltyBehavoir = require('./sharedRoyaltyToken.behavoir');
+const sharedRoyaltyBehavior = require('./sharedRoyaltyToken.behavior');
 
 contract('AbstractSharedRoyaltyToken', accounts => {
   /**
@@ -9,12 +9,12 @@ contract('AbstractSharedRoyaltyToken', accounts => {
    */
   const mintToken = async () => {
     const id = web3.utils.asciiToHex('super awesome token id');
-    const instance = await TestSharedRoyaltyToken.new();
+    const instance = await TestSharedRoyaltyToken.new(5);
 
     await instance.mint(accounts[0], id);
 
     return { token: instance, tokenId: id };
   };
 
-  sharedRoyaltyBehavoir(mintToken, accounts);
+  sharedRoyaltyBehavior(mintToken, accounts);
 });

--- a/packages/bootleg-tokens/test/BookendSharedRoyaltyToken.test.js
+++ b/packages/bootleg-tokens/test/BookendSharedRoyaltyToken.test.js
@@ -1,7 +1,6 @@
 const expect = require('jest-matchers');
-const BookendSharedRoyaltyToken = artifacts.require(
-  'BookendSharedRoyaltyToken'
-);
+const sharedRoyaltyBehavior = require('./sharedRoyaltyToken.behavior');
+const BookendSharedRoyaltyToken = artifacts.require('TestSharedRoyaltyToken');
 
 contract('BookendSharedRoyaltyToken', accounts => {
   const accountOne = accounts[0];
@@ -12,9 +11,22 @@ contract('BookendSharedRoyaltyToken', accounts => {
   let token;
   let balance;
 
-  beforeEach(async () => {
+  /**
+   * Mints a Bootleg token
+   *
+   * @returns {Promise<{TestSharedRoyaltyToken}>} - A SharedRoyalty Token instance
+   */
+  const mintToken = async () => {
     token = await BookendSharedRoyaltyToken.new(5);
     await token.mint(accountOne, tokenId);
+
+    return { token, tokenId };
+  };
+
+  sharedRoyaltyBehavior(mintToken, accounts);
+
+  beforeEach(async () => {
+    await mintToken();
   });
 
   describe('the first transfer', async () => {

--- a/packages/bootleg-tokens/test/sharedRoyaltyToken.behavior.js
+++ b/packages/bootleg-tokens/test/sharedRoyaltyToken.behavior.js
@@ -146,6 +146,7 @@ module.exports = (mintToken, accounts) => {
         value: oneEthInWei
       });
 
+      await util.tokenPaymentBalance(accounts[1]);
       await token.transferFrom(accounts[0], accounts[3], tokenId, {
         from: accounts[0],
         value: oneEthInWei
@@ -153,7 +154,16 @@ module.exports = (mintToken, accounts) => {
 
       expect(await util.franchisorWithdrawPaymentsLeft(accounts[0])).toEqual(4);
       expect(await util.tokenPaymentBalance(accounts[0])).toEqual(
-        web3.utils.toWei('2', 'ether')
+        web3.utils.toWei('3.9', 'ether')
+      );
+      expect(await util.tokenPaymentBalance(accounts[1])).toEqual(
+        web3.utils.toWei('.05', 'ether')
+      );
+      expect(await util.tokenPaymentBalance(accounts[2])).toEqual(
+        web3.utils.toWei('.05', 'ether')
+      );
+      expect(await util.tokenPaymentBalance(accounts[3])).toEqual(
+        web3.utils.toWei('0', 'ether')
       );
     });
   });


### PR DESCRIPTION
**Related Issue**  
Supports #98 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Uses the BookendToken in the BootlegTooken.

**Description of Changes**  
Removed `mintable` from the Bookend token and use it in the test token so downstream implementors can decide what kinda' mintable it should be.

I fixed me mispelling behavior 🤷‍♂️ 

**What gif most accurately describes how I feel towards this PR?**  
![boom](https://media2.giphy.com/media/mks5DcSGjhQ1a/giphy.gif)
