### PR TITLE
Added development network and flag for truffle to use test network

### DIFF
--- a/packages/bootleg-common/bin/bootleg-truffle-test
+++ b/packages/bootleg-common/bin/bootleg-truffle-test
@@ -5,6 +5,6 @@ set -e
 
 . bootleg-setup-ganache
 
-truffle test && bootleg-coverage-ignore && \
+truffle test --network test && bootleg-coverage-ignore && \
 istanbul report text html --include coverage/coverage.json && \
 istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100 --include coverage/coverage.json

--- a/packages/bootleg-common/truffle-config.js
+++ b/packages/bootleg-common/truffle-config.js
@@ -68,6 +68,11 @@ module.exports = projectRoot => {
 
   return {
     networks: {
+      development: {
+        host: '127.0.0.1',
+        port: 7545,
+        network_id: '*' // Match any network id
+      },
       test: {
         provider: () => {
           if (!testProviderStarted) {


### PR DESCRIPTION
**Related Issue**  
Supports #177 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Adds hardcoded test network to truffle test runs

**What gif most accurately describes how I feel towards this PR?**  
![If you just squint enough...](https://media.giphy.com/media/80mXWlPqTSU1y/giphy.gif)
